### PR TITLE
Extracted Flash function from Main and introduced retries

### DIFF
--- a/LibUsbDfu.csproj
+++ b/LibUsbDfu.csproj
@@ -31,7 +31,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>


### PR DESCRIPTION
This set of changes brought the success rate up from about 20% to 100% over 50 or so Flash attempts.

Across these attempts, observed roughly:
* a few (< 5) with 0 retries
* most with 1-2 retries
* 1 with 7 retries
* another with 8 retries

Set the MAX_RETRIES to 20, as the failure mode would leave a quadriplegic person's device completely inaccessible.

For the record, I'm not convinced at all that this is the right solution. I would much rather have the initial implementation work consistently without these retries.

Next up, I'd like to take this implementation to an interface that can be directly integrated with our larger application, rather than from a separate Console application.